### PR TITLE
PIZ-9 Limit input datatypes

### DIFF
--- a/app/report/generate-report.html
+++ b/app/report/generate-report.html
@@ -53,7 +53,15 @@
     </header>
 
 
-  <div class="container d-flex justify-content-center align-items-center">
+
+  <div class="container d-flex justify-content-center align-items-center flex-column">
+
+    <div id="report-alert" class="alert alert-success" role="alert" style="display: none">
+      <h4 class="alert-heading">Great!</h4>
+      <p>Your report was accepted successfully</p>
+    </div>
+
+
     <div class="jumbotron">
       <h2 class="text-center">Generate report</h2>
       <form id="report-form">

--- a/index.html
+++ b/index.html
@@ -71,14 +71,14 @@
           <div class="form-group row">
             <label class="col-sm-2 col-form-label">Name: </label>
             <div class="col-sm-10">
-              <input required name="name" type="text" class="form-control" placeholder="Name" />
+              <input required name="name" type="text" class="form-control" placeholder="Name" onkeydown="return /[a-z ]/i.test(event.key)" />
             </div>
           </div>
 
           <div class="form-group row">
             <label class="col-sm-2 col-form-label">DNI: </label>
             <div class="col-sm-10">
-              <input required name="dni" maxlength="10" type="text" class="form-control" placeholder="DNI" />
+              <input required name="dni" maxlength="10"  type="text" oninput="this.value = this.value.replace(/[^0-9.]/g, ''); this.value = this.value.replace(/(\..*)\./g, '$1');"  class="form-control" placeholder="DNI" />
             </div>
           </div>
 
@@ -92,7 +92,7 @@
           <div class="form-group row">
             <label class="col-sm-2 col-form-label">Phone #: </label>
             <div class="col-sm-10">
-              <input required name="phone" type="text" class="form-control" placeholder="Phone" />
+              <input required name="phone" type="text" oninput="this.value = this.value.replace(/[^0-9.]/g, ''); this.value = this.value.replace(/(\..*)\./g, '$1');"  class="form-control" placeholder="Phone" />
             </div>
           </div>
 

--- a/js/report/generate-report.js
+++ b/js/report/generate-report.js
@@ -51,3 +51,9 @@ function showNotification() {
     reportAlert.toggle();
     setTimeout(() => reportAlert.toggle(), 5000);
 }
+
+function showNotification() {
+    let reportAlert = $("#report-alert");
+    reportAlert.toggle();
+    setTimeout(() => reportAlert.toggle(), 5000);
+}


### PR DESCRIPTION
Ticket link: [PIZ-9](https://trello.com/c/IhjzHQzb/4-piz9-limit-the-inputs-data-types-in-the-frontend)

Description: Using regular expressions, the HTML code was adjusted for the correct datatype to be entered (such as numbers only into DNI)